### PR TITLE
added <, >, <=, >= operators

### DIFF
--- a/spec/csuuid_spec.cr
+++ b/spec/csuuid_spec.cr
@@ -99,4 +99,34 @@ describe CSUUID do
     (uuid2 <=> uuid1).should eq 1
     (uuid1 <=> uuid1).should eq 0
   end
+
+  it "can compare CSUUIDs via <" do
+    uuid1 = CSUUID.new
+    uuid2 = CSUUID.new
+    (uuid1 < uuid2).should be_true
+    (uuid2 < uuid1).should be_false
+  end
+
+  it "can compare CSUUIDs via >" do
+    uuid1 = CSUUID.new
+    uuid2 = CSUUID.new
+    (uuid1 > uuid2).should be_false
+    (uuid2 > uuid1).should be_true
+  end
+
+  it "can compare CSUUIDs via <=" do
+    uuid1 = CSUUID.new
+    uuid2 = CSUUID.new
+    (uuid1 <= uuid2).should be_true
+    (uuid2 <= uuid1).should be_false
+    (uuid1 <= uuid1).should be_true
+  end
+
+  it "can compare CSUUIDs via >=" do
+    uuid1 = CSUUID.new
+    uuid2 = CSUUID.new
+    (uuid1 >= uuid2).should be_false
+    (uuid2 >= uuid1).should be_true
+    (uuid1 >= uuid1).should be_true
+  end
 end

--- a/src/csuuid.cr
+++ b/src/csuuid.cr
@@ -180,4 +180,24 @@ struct CSUUID
 
     to_s <=> val.to_s
   end
+
+  # Returns `true` if `self` is less than *other*.
+  def <(other : CSUUID) : Bool
+    (self <=> other) == -1
+  end
+
+  # Returns `true` if `self` is greater than *other*.
+  def >(other : CSUUID) : Bool
+    (self <=> other) == 1
+  end
+
+  # Returns `true` if `self` is less than or equal to *other*.
+  def <=(other : CSUUID) : Bool
+    self == other || self < other
+  end
+
+  # Returns `true` if `self` is greater than or equal to *other*.
+  def >=(other : CSUUID) : Bool
+    self == other || self > other
+  end
 end


### PR DESCRIPTION
When people compare objects they often use operators like `==` and `<`. However, using `>` results in the following error: `Error: undefined method '>' for CSUUID`. The same happens with `<`, `>=` and `<=`.

This PR implements these four operators.

*Edit:* I just noticed that `#<=>` was implemented to make `CSUUID`s sortable and now I'm not sure if there is even a need for these four operators implemented in this PR?